### PR TITLE
Creating the first CI automatic pipeline for running tests

### DIFF
--- a/.github/workflows/run-java-tests.yaml
+++ b/.github/workflows/run-java-tests.yaml
@@ -1,0 +1,32 @@
+name: Run Java Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '18'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Run tests
+      - name: Run tests
+        run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,16 @@
         <maven.compiler.target>18</maven.compiler.target>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+        </plugins>
+    </build>
+
   <dependencies>
       <!-- Dependency used for easier tests -->
       <dependency>


### PR DESCRIPTION
> [!IMPORTANT]  
> Ahora cada vez que hagamos PR a la rama main, se va a ejecutar un pipeline automático que va a ejecutar todos los tests y así poder ver cuando nos hemos cargado algo. Aún así lo suyo es ejecutar los tests en local antes de hacer un push (o al menos una PR). Adjunto las imágenes de como se vería. Aún así, si todo está bien configurado en esta misma PR ya deberían estar ejecutándose
![passedtests](https://github.com/user-attachments/assets/c6614cf5-f175-4ae1-a55a-4f2022639091)
![failingtests](https://github.com/user-attachments/assets/44a6be56-9a4c-47b6-8493-9848691254ce)
