### PR TITLE
Github actions para desplegar las BD en contenedores de docker y generar report con el line coverage

### DIFF
--- a/.github/workflows/run-java-tests.yaml
+++ b/.github/workflows/run-java-tests.yaml
@@ -27,6 +27,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Set up Docker Compose
+        run: |
+          sudo apt-get install docker-compose
+
+      - name: Build and start containers with Docker Compose
+        run: |
+          docker-compose up -d
+
+      - name: Wait for databases to be ready
+        run: |
+          sleep 10
+
       # Generates report about line coverage
       - name: Build and test with coverage
         run: mvn clean verify

--- a/.github/workflows/run-java-tests.yaml
+++ b/.github/workflows/run-java-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 18
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -27,6 +27,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      # Run tests
-      - name: Run tests
-        run: mvn test
+      # Generates report about line coverage
+      - name: Build and test with coverage
+        run: mvn clean verify
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/site/jacoco/jacoco.xml
+          fail_ci_if_error: true

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,27 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/java/Database/ConnectionsTest.java
+++ b/src/test/java/Database/ConnectionsTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ConnectionsTest {
 
     @Test
-    @Disabled("Use this test to try if you have connection with MySQL database via Docker")
     public void tryMySQLConnection() throws SQLException {
         MySqlConnector c = new MySqlConnector();
         c.connectDatabase();
@@ -32,7 +31,6 @@ public class ConnectionsTest {
     }
 
     @Test
-    @Disabled("Use this test to try if you have connection with MongoDB database via Docker")
     public void tryMongoDBConnection() throws SQLException {
         MongoDBConnector c = new MongoDBConnector();
         c.connectDatabase();


### PR DESCRIPTION
Primero ejecutará el docker-compose up para levantar los contenedores. A continuación ejecuta todos los tests java, incluyendo los que pruebas las interacciones con la base de datos. Finalmente sube un archivo con el que reporta el line coverage. El link sale reflejado en el log del check automático.
![image](https://github.com/user-attachments/assets/702940b0-5127-46f3-9b7e-79e07e7c4fd8)
